### PR TITLE
changed ast to make conjunction a list of goals, modified parser and functions common accordingly

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -9,7 +9,7 @@ type const =
 type exp =
     | VarExp of string              (* variables                *)
     | ConstExp of const             (* constants                *)
-    | TermExp of string * exp list  (* functor(arg1, arg2, ...) *
+    | TermExp of string * exp list  (* functor(arg1, arg2, ...) *)
 
 (* Declarations *)
 type dec =

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -9,9 +9,7 @@ type const =
 type exp =
     | VarExp of string              (* variables                *)
     | ConstExp of const             (* constants                *)
-    | TermExp of string * exp list  (* functor(arg1, arg2, ...) *)
-    (*  | ConjunctionExp of exp * exp   (* term, term               *)*)
-(* | DisjunctionExp of exp * exp   (* term; term               *)*)
+    | TermExp of string * exp list  (* functor(arg1, arg2, ...) *
 
 (* Declarations *)
 type dec =

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -10,13 +10,13 @@ type exp =
     | VarExp of string              (* variables                *)
     | ConstExp of const             (* constants                *)
     | TermExp of string * exp list  (* functor(arg1, arg2, ...) *)
-    | ConjunctionExp of exp * exp   (* term, term               *)
-    | DisjunctionExp of exp * exp   (* term; term               *)
+    (*  | ConjunctionExp of exp * exp   (* term, term               *)*)
+(* | DisjunctionExp of exp * exp   (* term; term               *)*)
 
 (* Declarations *)
 type dec =
-    | Clause of exp * exp   (* Head :- Body. *)
-    | Query of exp          (* ?- Body.      *)
+    | Clause of exp * (exp list)  (* Head :- Body. *)
+    | Query of (exp list)         (* ?- Body.      *)
 
 (* Results *)
 type res =

--- a/src/common.ml
+++ b/src/common.ml
@@ -27,7 +27,6 @@ let string_of_token t =
     | LPAREN    -> "LPAREN"
     | RPAREN    -> "RPAREN"
     | COMMA     -> "COMMA"
-    | SEMICOLON -> "SEMICOLON"
     | EOF       -> "EOF"
 
 let string_of_token_list tl =

--- a/src/common.ml
+++ b/src/common.ml
@@ -47,15 +47,19 @@ let rec string_of_exp e =
     | TermExp (f, args) ->
         let func = String.escaped f in
             "TermExp (\"" ^ func ^ "\", [" ^ (String.concat "; " (List.map string_of_exp args)) ^ "])"
-    | ConjunctionExp (e1, e2) ->
+(*    | ConjunctionExp (e1, e2) ->
         "ConjunctionExp (" ^ (string_of_exp e1) ^ ", " ^ (string_of_exp e2) ^ ")"
     | DisjunctionExp (e1, e2) ->
         "DisjunctionExp (" ^ (string_of_exp e1) ^ ", " ^ (string_of_exp e2) ^ ")"
+ *)
 
+
+let string_of_goals g = "[" ^ (String.concat "; " (List.map string_of_exp g)) ^ "]"
+                      
 let string_of_dec d =
     match d with
-    | Clause (e1, e2) -> "Clause (" ^ (string_of_exp e1) ^ ", " ^ (string_of_exp e2) ^ ")"
-    | Query e -> "Query (" ^ (string_of_exp e) ^ ")"
+    | Clause (e1, g) -> "Clause (" ^ (string_of_exp e1) ^ ", " ^ (string_of_goals g) ^ ")"
+    | Query g -> "Query (" ^ (string_of_goals g) ^ ")"
 
 let string_of_db db =
     "[" ^ (String.concat "; " (List.map string_of_dec db)) ^ "]"

--- a/src/common.ml
+++ b/src/common.ml
@@ -47,11 +47,6 @@ let rec string_of_exp e =
     | TermExp (f, args) ->
         let func = String.escaped f in
             "TermExp (\"" ^ func ^ "\", [" ^ (String.concat "; " (List.map string_of_exp args)) ^ "])"
-(*    | ConjunctionExp (e1, e2) ->
-        "ConjunctionExp (" ^ (string_of_exp e1) ^ ", " ^ (string_of_exp e2) ^ ")"
-    | DisjunctionExp (e1, e2) ->
-        "DisjunctionExp (" ^ (string_of_exp e1) ^ ", " ^ (string_of_exp e2) ^ ")"
- *)
 
 
 let string_of_goals g = "[" ^ (String.concat "; " (List.map string_of_exp g)) ^ "]"

--- a/src/common.ml
+++ b/src/common.ml
@@ -67,5 +67,8 @@ let string_of_db db =
 let print_db db =
     print_endline (string_of_db db)
 
-let string_of_res r =
-    raise (Failure "Not implemented yet")
+let string_of_atom a =
+    match a with
+    | (TermExp(s,_)) -> s
+    | _ -> raise(Failure "not needed")
+               

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -1,10 +1,10 @@
 open Ast
 open Common
 let (fresh, reset) =
-   let nxt = ref 0 in
-   let f () = (nxt := !nxt + 1; string_of_int (!nxt)) in
-   let r () = nxt := 0 in
-    (f, r) 
+  let nxt = ref 0 in
+  let f () = (nxt := !nxt + 1; string_of_int (!nxt)) in
+  let r () = nxt := 0 in
+  (f, r) 
 
 let found_solution = ref false
                    
@@ -17,8 +17,8 @@ let rec find_vars q  = match q with [] -> []
 let uniq l =
   let rec tail_uniq a l =
     match l with
-      | [] -> a
-      | hd::tl -> tail_uniq (hd::a) (List.filter (fun x -> x  != hd) tl) in
+    | [] -> a
+    | hd::tl -> tail_uniq (hd::a) (List.filter (fun x -> x  <> hd) tl) in
   tail_uniq [] l
 
 let rec sub_lift_goal sub g =
@@ -27,7 +27,7 @@ let rec sub_lift_goal sub g =
                                                | Some(i) -> i)
   | TermExp(s,el) -> TermExp(s, List.map (fun g1 -> sub_lift_goal sub g1) el)
   | _  -> g
-                                              
+       
 let rec sub_lift_goals sub g = List.map (fun g1 -> sub_lift_goal sub g1) g
 let rec rename_vars_in_clause c =
   match c with
@@ -39,19 +39,19 @@ let rec rename_vars_in_clause c =
      Clause(sub_lift_goal sub h, sub_lift_goals sub b)
   | _ -> raise(Failure "not needed")
 let add_clause_to_db (dec,db) =
-    match dec with
-    | Clause (h,b) -> (match h with TermExp("true",_) -> print_string "can't reassign true predicate\n"; db
-                                 | _ -> db @ [dec])
-    | _ -> raise(Failure "not needed")
+  match dec with
+  | Clause (h,b) -> (match h with TermExp("true",_) -> print_string "can't reassign true predicate\n"; db
+                               | _ -> db @ [dec])
+  | _ -> raise(Failure "not needed")
 let rec pairandcat sargs targs c = match sargs with [] -> c
                                                   | (s::ss) -> match targs with (t::ts) -> pairandcat ss ts ((s,t)::c)
-                                                                             |  _ -> raise(Failure "not needed")
+                                                                            |  _ -> raise(Failure "not needed")
 let rec replace c sub = match c with [] -> []
                                    | ((s,t)::xs) -> (sub_lift_goal sub s, sub_lift_goal sub t)::(replace xs sub)
 let rec occurs s t = match s with VarExp(n) -> (match t with VarExp(m) -> n = m
                                                           | TermExp(st,el) -> List.fold_left (fun acc v -> acc || (occurs s v)) false el
                                                           | _ -> false)
-                                |  _ -> raise(Failure "not needed")
+                               |  _ -> raise(Failure "not needed")
 let rec unify constraints =
   match constraints with
   | [] -> Some([])
@@ -74,61 +74,68 @@ let rec unify constraints =
                                                  | _ -> None)
                                   | _ -> None
 
-    
+                                      
 let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
-    match q with 
-    | [] -> (match unify env with
-            | Some(e2) ->
-              found_solution := true;
-              (if (orig_vars_num > 0) then print_string "====================\n");
-          
-              List.fold_right (fun d r ->
-                 ( match d with VarExp(v) ->
-                     (match List.assoc_opt (VarExp(v)) e2 with
-                      | Some(TermExp(st,el)) ->  print_string (v ^ " = " ^ (string_of_atom ((TermExp(st,el))) ^ "\n")); r
-                      | Some(VarExp(v2)) ->  print_string (v ^ " is free\n");r
-                      | Some(_) -> raise(Failure "not needed")
-                      | None -> print_string (v ^ " is free\n");r)
-                              | _ ->  raise(Failure "not needed")
+  match q with 
+  | [] -> (
+    found_solution := true;
+    (if (orig_vars_num > 0) then print_string "====================\n");
+    
+    List.fold_right (fun d r ->
+        ( match d with VarExp(v) ->
+                       (match List.assoc_opt (VarExp(v)) env with
+                        | Some(TermExp(st,el)) ->  print_string (v ^ " = " ^ (string_of_atom ((TermExp(st,el))) ^ "\n")); r
+                        | Some(VarExp(v2)) ->  print_string (v ^ " is free\n");r
+                        | Some(_) -> raise(Failure "not needed")
+                        | None -> print_string (v ^ " is free\n");r)
+                     | _ ->  raise(Failure "not needed")
+        )
+      )
+                    (orig_query_vars) ();
+    
+    (if (orig_vars_num > 0) then print_string "====================\n");
+    
+  )
+  | (g1::gl) -> (
+    for i = 0 to ((List.length db)-1) do
+      let rulei = List.nth db i in
+      match (rename_vars_in_clause rulei) with
+      | Clause(h,b) ->
+         (match unify [(g1, h)] with
+          | Some(s) ->
+             (match unify (s@env) with
+              | Some(env2) ->
+                 (if (List.length b = 1 )
+                  then
+                    (match b with ((ConstExp (BoolConst true))::ys) ->
+                                  eval_query (sub_lift_goals s gl, db, env2, orig_query_vars,  orig_vars_num)
+                                | _ ->  eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, env2, orig_query_vars, orig_vars_num))
+                  else 
+                    eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, env2, orig_query_vars,  orig_vars_num)
+                 
                  )
-                )
-                       orig_query_vars ();
+              | _ -> ()
+             )
+          | _ -> ()
+              
+         )
+      |  _ -> raise(Failure "not needed")
            
-             (if (orig_vars_num > 0) then print_string "====================\n");
-            | _ -> ())
-    | (g1::gl) ->
-       (for i = 0 to ((List.length db)-1) do
-          let rulei = List.nth db i in
-          match (rename_vars_in_clause rulei) with
-          | Clause(h,b) ->
-            (match unify [(g1, h)] with
-             | Some(s) ->
-                if (List.length b = 1 )
-                then
-                  (match b with ((ConstExp (BoolConst true))::ys) ->
-                     eval_query (sub_lift_goals s gl, db, (s@env), orig_query_vars,  orig_vars_num)
-                               | _ ->  eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, (s@env), orig_query_vars, orig_vars_num))
-                else 
-                  eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, (s@env), orig_query_vars,  orig_vars_num)
-             | _ -> ()
-            )
-          |  _ -> raise(Failure "not needed")
-                         
-        done
-       )
- 
+    done
+  )
+    
 
-  
+    
 let eval_dec (dec, db) =
-    match dec with
-    | Clause(h,b) -> add_clause_to_db (dec, db)
-    | Query(b) -> (let orig_vars = uniq (find_vars b) in
-                 let orig_vars_num = List.length orig_vars in
+  match dec with
+  | Clause(h,b) -> add_clause_to_db (dec, db)
+  | Query(b) -> (let orig_vars = uniq (find_vars b) in
+                let orig_vars_num = List.length orig_vars in
                 
-                 eval_query (b, db, [], orig_vars, orig_vars_num);
-                    (if (!found_solution = false)
-                    then print_string "false\n"
-                                      (*else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));*)
-                     else ( (print_string "true\n"); found_solution := false));
-                    db)
-   
+                eval_query (b, db, [], orig_vars, orig_vars_num);
+                (if (!found_solution = false)
+                 then print_string "false\n"
+                                   (*else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));*)
+                 else ( (print_string "true\n"); found_solution := false));
+                db)
+             

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -9,10 +9,11 @@ let (fresh, reset) =
   (f, r) 
 
 let found_solution = ref false
-                   
+let more_solutions = ref true
+let all_solutions = ref false                   
 let rec find_vars q  =
   match q with [] -> []
-             | (x::xs) -> (match x with VarExp(v) -> [x] @ (find_vars xs)
+             | (x::xs) -> (match x with VarExp(v) -> x :: (find_vars xs)
                                      | ConstExp(c) -> (find_vars xs)
                                      | TermExp(s,el) -> (find_vars el) @ (find_vars xs))
                        
@@ -78,9 +79,17 @@ let rec unify constraints =
                                                  | _ -> None)
                                   | _ -> None
 
+ let rec getResp u = 
+    print_string "More Answers? (Y)es/(N)o/(A)ll\t";
+    (match (read_line ()) with
+    | "Y" -> ()
+    | "N" -> more_solutions := false; ()
+    | "A" -> all_solutions := true; more_solutions := true; ()
+    | _ -> print_string "Didn't understand input. Try Again.\n"; getResp () )                                      
                                       
 let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
-  match q with 
+  if ((!more_solutions) = true) then
+  (match q with 
   | [] -> (
     found_solution := true;
     (if (orig_vars_num > 0) then print_string "====================\n");
@@ -100,8 +109,9 @@ let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
     
     (if (orig_vars_num > 0) then print_string "====================\n");
     
+    if (((!all_solutions) = false) && (orig_vars_num > 0)) then getResp ();
   )
-  | (g1::gl) -> (
+   | (g1::gl) -> (
     List.fold_right (fun rule r ->
       
       match (rename_vars_in_clause rule) with
@@ -127,6 +137,7 @@ let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
       |  _ -> raise(Failure "not needed")
            
       ) db () 
+   )
   )
              
 
@@ -141,6 +152,6 @@ let eval_dec (dec, db) =
                 (if (!found_solution = false)
                  then print_string "false\n"
                                    (*else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));*)
-                 else ( (print_string "true\n"); found_solution := false));
+                 else ( (print_string "true\n"); found_solution := false; more_solutions := true; all_solutions := false));
                 db)
              

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -1,5 +1,7 @@
 open Ast
 open Common
+
+
 let (fresh, reset) =
   let nxt = ref 0 in
   let f () = (nxt := !nxt + 1; string_of_int (!nxt)) in
@@ -8,11 +10,12 @@ let (fresh, reset) =
 
 let found_solution = ref false
                    
-let rec find_vars q  = match q with [] -> []
-                                  | (x::xs) -> (match x with VarExp(v) -> [x] @ (find_vars xs)
-                                                          | ConstExp(c) -> (find_vars xs)
-                                                          | TermExp(s,el) -> (find_vars el) @ (find_vars xs))
-                                            
+let rec find_vars q  =
+  match q with [] -> []
+             | (x::xs) -> (match x with VarExp(v) -> [x] @ (find_vars xs)
+                                     | ConstExp(c) -> (find_vars xs)
+                                     | TermExp(s,el) -> (find_vars el) @ (find_vars xs))
+                       
 (* from https://rosettacode.org/wiki/Remove_duplicate_elements#OCaml *)
 let uniq l =
   let rec tail_uniq a l =
@@ -123,9 +126,9 @@ let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
            
     done
   )
-    
+             
 
-    
+             
 let eval_dec (dec, db) =
   match dec with
   | Clause(h,b) -> add_clause_to_db (dec, db)

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -1,31 +1,26 @@
 open Ast
 
+let (fresh, reset) =
+   let nxt = ref 0 in
+   let f () = (nxt := !nxt + 1; string_of_int (!nxt)) in
+   let r () = nxt := 0 in
+    (f, r) 
 
-let rec check_if_dec_in_db (Clause (h, b), db) =
-    match db with
-    | [] -> false
-    | ((Clause (h1, b1)) :: xs) ->
-        if h = h1
-        then true
-        else check_if_dec_in_db (Clause (h,b) ,xs)
 
-let rec update_dec_in_db (Clause (h, newb), db) =
-    match db with
-    | [] -> []
-    | ((Clause (h1, b1)) :: xs) ->
-        if h = h1
-        then (Clause (h, newb)) :: xs
-        else (Clause (h1, b1)) :: (update_dec_in_db (Clause (h, newb), xs))
+
 
 let add_clause_to_db (dec,db) =
     match dec with
-    Clause (h,b) ->
-        let r = check_if_dec_in_db (dec, db) in
-            if r
-            then update_dec_in_db (dec, db)
-            else (Clause (h, b)) :: db
+    Clause (h,b) -> dec :: db
 
+(*let eval_query (q, db, env) =
+    match q with 
+    | TermExp(s,el) -> loop_term_in_db (s,e1) db env
+    | ConjunctionExp(e1,e2) -> (match eval_query (lift_sub_goal e1 env) with
+                               | None -> None
+                               | Some(s1) -> eval_query (lift_sub_goal (lift_sub_goal e2 env) s1)
+ *)
 let eval_dec (dec, db) =
     match dec with
     | Clause(h,b) -> (add_clause_to_db (dec, db), None)
-    | Query(b) -> raise (Failure "Not Implementing right now")
+    | Query(b) -> raise (Failure "not implemented")

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -41,7 +41,7 @@ let rec rename_vars_in_clause c =
 let add_clause_to_db (dec,db) =
     match dec with
     | Clause (h,b) -> (match h with TermExp("true",_) -> print_string "can't reassign true predicate\n"; db
-                                 | _ -> dec:: db)
+                                 | _ -> db @ [dec])
     | _ -> raise(Failure "not needed")
 let rec pairandcat sargs targs c = match sargs with [] -> c
                                                   | (s::ss) -> match targs with (t::ts) -> pairandcat ss ts ((s,t)::c)

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -1,26 +1,132 @@
 open Ast
-
+open Common
 let (fresh, reset) =
    let nxt = ref 0 in
    let f () = (nxt := !nxt + 1; string_of_int (!nxt)) in
    let r () = nxt := 0 in
     (f, r) 
 
+let found_solution = ref false
+                   
+let rec find_vars q  = match q with [] -> []
+                                  | (x::xs) -> (match x with VarExp(v) -> [x] @ (find_vars xs)
+                                                          | ConstExp(c) -> (find_vars xs)
+                                                          | TermExp(s,el) -> (find_vars el) @ (find_vars xs))
+                                            
+(* from https://rosettacode.org/wiki/Remove_duplicate_elements#OCaml *)
+let uniq l =
+  let rec tail_uniq a l =
+    match l with
+      | [] -> a
+      | hd::tl -> tail_uniq (hd::a) (List.filter (fun x -> x  != hd) tl) in
+  tail_uniq [] l
 
-
-
+let rec sub_lift_goal sub g =
+  match g with
+  | VarExp(v) ->(match  List.assoc_opt g sub with None -> VarExp(v)
+                                               | Some(i) -> i)
+  | TermExp(s,el) -> TermExp(s, List.map (fun g1 -> sub_lift_goal sub g1) el)
+  | _  -> g
+                                              
+let rec sub_lift_goals sub g = List.map (fun g1 -> sub_lift_goal sub g1) g
+let rec rename_vars_in_clause c =
+  match c with
+  | Clause(h,b) ->
+     let head_vars = find_vars [h] in
+     let body_vars = find_vars b in
+     let vars = uniq (head_vars @ body_vars) in
+     let sub = List.map (fun x -> (x, VarExp(fresh()))) vars in
+     Clause(sub_lift_goal sub h, sub_lift_goals sub b)
+  | _ -> raise(Failure "not needed")
 let add_clause_to_db (dec,db) =
     match dec with
-    Clause (h,b) -> dec :: db
+    | Clause (h,b) -> (match h with TermExp("true",_) -> print_string "can't reassign true predicate\n"; db
+                                 | _ -> dec:: db)
+    | _ -> raise(Failure "not needed")
+let rec pairandcat sargs targs c = match sargs with [] -> c
+                                                  | (s::ss) -> match targs with (t::ts) -> pairandcat ss ts ((s,t)::c)
+                                                                             |  _ -> raise(Failure "not needed")
+let rec replace c sub = match c with [] -> []
+                                   | ((s,t)::xs) -> (sub_lift_goal sub s, sub_lift_goal sub t)::(replace xs sub)
+let rec occurs s t = match s with VarExp(n) -> (match t with VarExp(m) -> n = m
+                                                          | TermExp(st,el) -> List.fold_left (fun acc v -> acc || (occurs s v)) false el
+                                                          | _ -> false)
+                                |  _ -> raise(Failure "not needed")
+let rec unify constraints =
+  match constraints with
+  | [] -> Some([])
+  | ((s,t)::c') -> if s = t
+                  then unify c'
+                  else match s with VarExp(n) ->
+                                    if (occurs s t)
+                                    then None
+                                    else let sub = [(s,t)] in
+                                         let c'' = replace c' sub in
+                                         let phi = unify c'' in
+                                         (match phi with None -> None
+                                                       | Some(l) -> Some((s, sub_lift_goal l t)::l))
+                                  | TermExp(sname,sargs) ->
+                                     (match t with VarExp(k) -> unify ((t,s)::c')
+                                                 | TermExp(tname,targs) ->
+                                                    if (tname = sname && List.length targs = List.length sargs)
+                                                    then unify (pairandcat sargs targs c')
+                                                    else None
+                                                 | _ -> None)
+                                  | _ -> None
 
-(*let eval_query (q, db, env) =
+    
+let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
     match q with 
-    | TermExp(s,el) -> loop_term_in_db (s,e1) db env
-    | ConjunctionExp(e1,e2) -> (match eval_query (lift_sub_goal e1 env) with
-                               | None -> None
-                               | Some(s1) -> eval_query (lift_sub_goal (lift_sub_goal e2 env) s1)
- *)
+    | [] -> (match unify env with
+            | Some(e2) ->
+              found_solution := true;
+              (if (orig_vars_num > 0) then print_string "====================\n");
+          
+              List.fold_right (fun d r ->
+                 ( match d with VarExp(v) ->
+                     (match List.assoc_opt (VarExp(v)) e2 with
+                      | Some(TermExp(st,el)) ->  print_string (v ^ " = " ^ (string_of_atom ((TermExp(st,el))) ^ "\n")); r
+                      | Some(_) ->  raise(Failure "not needed")                                        
+                      | None -> print_string (v ^ " is free\n");r)
+                              | _ ->  raise(Failure "not needed")
+                 )
+                )
+                       orig_query_vars ();
+           
+             (if (orig_vars_num > 0) then print_string "====================\n");
+            | _ -> ())
+    | (g1::gl) ->
+       (for i = 0 to ((List.length db)-1) do
+          let rulei = List.nth db i in
+          match (rename_vars_in_clause rulei) with
+          | Clause(h,b) ->
+            (match unify [(g1, h)] with
+             | Some(s) ->
+                if (List.length b = 1 )
+                then
+                  (match b with ((ConstExp (BoolConst true))::ys) ->
+                     eval_query (sub_lift_goals s gl, db, (s@env), orig_query_vars,  orig_vars_num)
+                               | _ ->  eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, (s@env), orig_query_vars, orig_vars_num))
+                else 
+                  eval_query ((sub_lift_goals s b) @ (sub_lift_goals s gl), db, (s@env), orig_query_vars,  orig_vars_num)
+             | _ -> ()
+            )
+          |  _ -> raise(Failure "not needed")
+                         
+        done
+       )
+ 
+
+  
 let eval_dec (dec, db) =
     match dec with
-    | Clause(h,b) -> (add_clause_to_db (dec, db), None)
-    | Query(b) -> raise (Failure "not implemented")
+    | Clause(h,b) -> add_clause_to_db (dec, db)
+    | Query(b) -> (let orig_vars = uniq (find_vars b) in
+                 let orig_vars_num = List.length orig_vars in
+                
+                 eval_query (b, db, [], orig_vars, orig_vars_num);
+                    (if (!found_solution = false)
+                    then print_string "false\n"
+                    else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));
+                    db)
+   

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -86,7 +86,8 @@ let rec eval_query (q, db, env, orig_query_vars, orig_vars_num) =
                  ( match d with VarExp(v) ->
                      (match List.assoc_opt (VarExp(v)) e2 with
                       | Some(TermExp(st,el)) ->  print_string (v ^ " = " ^ (string_of_atom ((TermExp(st,el))) ^ "\n")); r
-                      | Some(_) ->  raise(Failure "not needed")                                        
+                      | Some(VarExp(v2)) ->  print_string (v ^ " is free\n");r
+                      | Some(_) -> raise(Failure "not needed")
                       | None -> print_string (v ^ " is free\n");r)
                               | _ ->  raise(Failure "not needed")
                  )
@@ -127,6 +128,7 @@ let eval_dec (dec, db) =
                  eval_query (b, db, [], orig_vars, orig_vars_num);
                     (if (!found_solution = false)
                     then print_string "false\n"
-                    else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));
+                                      (*else (if (orig_vars_num = 0) then (print_string "true\n"); found_solution := false));*)
+                     else ( (print_string "true\n"); found_solution := false));
                     db)
    

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -84,7 +84,6 @@ rule token = parse
     | '('                   { LPAREN    }
     | ')'                   { RPAREN    }
     | ','                   { COMMA     }
-    | ';'                   { SEMICOLON }
 
 and comments count = parse
     | open_comment          { comments (1 + count) lexbuf }

--- a/src/main.ml
+++ b/src/main.ml
@@ -35,8 +35,7 @@ let _ =
            | Parsing.Parse_error ->
              (print_string "\ndoes not parse\n";
               loop db)
-           | _ -> (print_string "\ndoes not work\n";
-              loop db));
+           );
        
   with Lexer.EndInput -> exit 0
  in (loop [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])] )

--- a/src/main.ml
+++ b/src/main.ml
@@ -34,6 +34,9 @@ let _ =
                            loop db)
            | Parsing.Parse_error ->
              (print_string "\ndoes not parse\n";
-              loop db)); 
+              loop db)
+           | _ -> (print_string "\ndoes not work\n";
+              loop db));
+       
   with Lexer.EndInput -> exit 0
  in (loop [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])] )

--- a/src/main.ml
+++ b/src/main.ml
@@ -13,7 +13,7 @@ let _ =
       then print_endline "\nWelcome to the Prolog Interpreter \n"
       else ());
   let rec loop db =
-  print_db db;
+    (* print_db db;*)
   try
     let lexbuf = Lexing.from_channel stdin
     in (if is_interactive 
@@ -26,9 +26,7 @@ let _ =
 				    | r -> r)
                     lexbuf 
           in 
-             let (newdb,res) = eval_dec (dec,db) in
-             (match res with  None ->  loop newdb
-                            | _ -> raise (Failure "Not impelmented yet"))
+             let newdb = eval_dec (dec,db) in loop newdb
             
         with Failure s -> (print_newline();
 			   print_endline s;
@@ -38,4 +36,4 @@ let _ =
              (print_string "\ndoes not parse\n";
               loop db)); 
   with Lexer.EndInput -> exit 0
- in (loop [])
+ in (loop [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])] )

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -9,7 +9,7 @@
     let fact_sugar p =
         Clause (
             p,
-            ConstExp (BoolConst true)
+            [ConstExp (BoolConst true)]
         )
 
     (* An atom can be regarded as a compound term with arity zero *)
@@ -54,8 +54,8 @@
 
 /* Types */
 %type <Ast.dec> clause
-%type <Ast.exp> predicate_list predicate term structure
-%type <Ast.exp list> term_list
+%type <Ast.exp> predicate term structure
+%type <Ast.exp list> term_list predicate_list 
 %type <Ast.const> constant
 
 %%
@@ -66,9 +66,9 @@ clause:
     | QUERY; pl = predicate_list; PERIOD                { Query pl }
 
 predicate_list:
-    | p = predicate                                     { p }
-    | pl = predicate_list; COMMA;     p = predicate     { ConjunctionExp (pl, p) }
-    | pl = predicate_list; SEMICOLON; p = predicate     { DisjunctionExp (pl, p) }
+    | p = predicate                                     { [p] }
+    | p = predicate; COMMA; pl = predicate_list        { p :: pl }
+ (*   | pl = predicate_list; SEMICOLON; p = predicate     { DisjunctionExp (pl, p) }*)
 
 predicate:
     | a = ATOM                                          { atom_sugar a }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -44,7 +44,6 @@
 %token LPAREN     /* (  */
 %token RPAREN     /* )  */
 %token COMMA      /* ,  */
-%token SEMICOLON  /* ;  */
 
 /* Meta-characters */
 %token EOF
@@ -67,8 +66,7 @@ clause:
 
 predicate_list:
     | p = predicate                                     { [p] }
-    | p = predicate; COMMA; pl = predicate_list        { p :: pl }
- (*   | pl = predicate_list; SEMICOLON; p = predicate     { DisjunctionExp (pl, p) }*)
+    | p = predicate; COMMA; pl = predicate_list         { p :: pl }
 
 predicate:
     | a = ATOM                                          { atom_sugar a }

--- a/tests/common_test.ml
+++ b/tests/common_test.ml
@@ -53,6 +53,8 @@ let common_test_suite =
                 TermExp ("coord", [VarExp "X"; VarExp "Y"; VarExp "Z"])
             ), "TermExp (\"coord\", [VarExp \"X\"; VarExp \"Y\"; VarExp \"Z\"])";
             
+            string_of_atom (TermExp("blah",[])),    "blah";
+            
             (* Declarations *)
             string_of_dec (
                 Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
@@ -71,6 +73,6 @@ let common_test_suite =
                 Clause (TermExp ("foo", []), [ConstExp (BoolConst true)]);
                 Query ([TermExp ("bar", [])])
             ]; "print_db"), "print_db";
-
+            
         ]
     )

--- a/tests/common_test.ml
+++ b/tests/common_test.ml
@@ -33,7 +33,6 @@ let common_test_suite =
             string_of_token LPAREN,         "LPAREN";
             string_of_token RPAREN,         "RPAREN";
             string_of_token COMMA,          "COMMA";
-            string_of_token SEMICOLON,      "SEMICOLON";
             string_of_token EOF,            "EOF";
 
             string_of_token_list [
@@ -53,30 +52,24 @@ let common_test_suite =
             string_of_exp (
                 TermExp ("coord", [VarExp "X"; VarExp "Y"; VarExp "Z"])
             ), "TermExp (\"coord\", [VarExp \"X\"; VarExp \"Y\"; VarExp \"Z\"])";
-            string_of_exp (
-                ConjunctionExp (TermExp ("cat", []), TermExp ("dog", []))
-            ), "ConjunctionExp (TermExp (\"cat\", []), TermExp (\"dog\", []))";
-            string_of_exp (
-                DisjunctionExp (TermExp ("cat", []), TermExp ("dog", []))
-            ), "DisjunctionExp (TermExp (\"cat\", []), TermExp (\"dog\", []))";
-
+            
             (* Declarations *)
             string_of_dec (
-                Clause (TermExp ("cat", []), ConstExp (BoolConst true))
-            ), "Clause (TermExp (\"cat\", []), ConstExp (BoolConst true))";
+                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
+            ), "Clause (TermExp (\"cat\", []), [ConstExp (BoolConst true)])";
             string_of_dec (
-                Query (TermExp ("cat", [TermExp ("tom", [])]))
-            ), "Query (TermExp (\"cat\", [TermExp (\"tom\", [])]))";
+                Query ([TermExp ("cat", [TermExp ("tom", [])])])
+            ), "Query ([TermExp (\"cat\", [TermExp (\"tom\", [])])])";
 
             (* Database *)
             string_of_db [
-                Clause (TermExp ("foo", []), ConstExp (BoolConst true));
-                Query (TermExp ("bar", []))
-            ], "[Clause (TermExp (\"foo\", []), ConstExp (BoolConst true)); Query (TermExp (\"bar\", []))]";
+                Clause (TermExp ("foo", []), [ConstExp (BoolConst true)]);
+                Query ([TermExp ("bar", [])])
+            ], "[Clause (TermExp (\"foo\", []), [ConstExp (BoolConst true)]); Query ([TermExp (\"bar\", [])])]";
 
             (print_db [
-                Clause (TermExp ("foo", []), ConstExp (BoolConst true));
-                Query (TermExp ("bar", []))
+                Clause (TermExp ("foo", []), [ConstExp (BoolConst true)]);
+                Query ([TermExp ("bar", [])])
             ]; "print_db"), "print_db";
 
         ]

--- a/tests/lexer_test.ml
+++ b/tests/lexer_test.ml
@@ -92,7 +92,6 @@ let lexer_test_suite =
             "(",        [LPAREN];
             ")",        [RPAREN];
             ",",        [COMMA];
-            ";",        [SEMICOLON];
             ":- ?- ()", [RULE; QUERY; LPAREN; RPAREN];
 
             (* Comments *)

--- a/tests/parser_test.ml
+++ b/tests/parser_test.ml
@@ -20,157 +20,67 @@ let parser_test_suite =
         [
             (* Facts *)
             "cat.", (
-                Clause (TermExp ("cat", []), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
             );
             "cat().", (
-                Clause (TermExp ("cat", []), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
             );
             "cat(tom).", (
-                Clause (TermExp ("cat", [TermExp ("tom", [])]), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)])
             );
             "cat(tom()).", (
-                Clause (TermExp ("cat", [TermExp ("tom", [])]), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)])
             );
             "cat(X).", (
-                Clause (TermExp ("cat", [VarExp "X"]), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", [VarExp "X"]), [ConstExp (BoolConst true)])
             );
             "coord(X, Y, Z).", (
-                Clause (
-                    TermExp ("coord", [VarExp "X"; VarExp "Y"; VarExp "Z"]),
-                    ConstExp (BoolConst true)
-                )
+                Clause (TermExp ("coord", [VarExp "X"; VarExp "Y"; VarExp "Z"]), [ConstExp (BoolConst true)])
             );
             "coord(1, 2, 3).", (
-                Clause (
-                    TermExp ("coord", [
-                        ConstExp (IntConst 1);
-                        ConstExp (IntConst 2);
-                        ConstExp (IntConst 3)
-                    ]),
-                    ConstExp (BoolConst true)
-                )
+                Clause (TermExp ("coord", [ConstExp (IntConst 1); ConstExp (IntConst 2); ConstExp (IntConst 3)]), [ConstExp (BoolConst true)])
             );
             "coord(1.0, 2.0, 3.0).", (
-                Clause (
-                    TermExp ("coord", [
-                        ConstExp (FloatConst 1.);
-                        ConstExp (FloatConst 2.);
-                        ConstExp (FloatConst 3.)
-                    ]),
-                    ConstExp (BoolConst true)
-                )
+                Clause (TermExp ("coord", [ConstExp (FloatConst 1.); ConstExp (FloatConst 2.); ConstExp (FloatConst 3.)]), [ConstExp (BoolConst true)])
+
             );
             "cousins(\"jack\", \"jill\").", (
-                Clause (
-                    TermExp ("cousins", [
-                        ConstExp (StringConst "jack");
-                        ConstExp (StringConst "jill")
-                    ]),
-                    ConstExp (BoolConst true)
-                )
+               Clause (TermExp ("cousins", [ConstExp (StringConst "jack"); ConstExp (StringConst "jill")]), [ConstExp (BoolConst true)])
+
             );
 
             (* Rules *)
             "animal(X) :- cat(X).", (
-                Clause (TermExp ("animal", [VarExp "X"]), TermExp ("cat", [VarExp "X"]))
+                Clause (TermExp ("animal", [VarExp "X"]), [TermExp ("cat", [VarExp "X"])])
             );
             "sibling(X, Y) :- parent_child(Z, X), parent_child(Z, Y).", (
-                Clause (
-                    TermExp ("sibling", [VarExp "X"; VarExp "Y"]),
-                    ConjunctionExp (
-                        TermExp ("parent_child", [VarExp "Z"; VarExp "X"]),
-                        TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])
-                    )
-                )
+                Clause (TermExp ("sibling", [VarExp "X"; VarExp "Y"]), [TermExp ("parent_child", [VarExp "Z"; VarExp "X"]); TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])])
             );
-            "sibling(X, Y) :- parent_child(Z, X); parent_child(Z, Y).", (
-                Clause (
-                    TermExp ("sibling", [VarExp "X"; VarExp "Y"]),
-                    DisjunctionExp (
-                        TermExp ("parent_child", [VarExp "Z"; VarExp "X"]),
-                        TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])
-                    )
-                )
-            );
+           
             "nonsense_words :- foo, bar, baz.", (
-                Clause (
-                    TermExp ("nonsense_words", []),
-                    ConjunctionExp (
-                        ConjunctionExp (
-                            TermExp ("foo", []),
-                            TermExp ("bar", [])
-                        ),
-                        TermExp ("baz", [])
-                    )
-                )
+                Clause (TermExp ("nonsense_words", []), [TermExp ("foo", []); TermExp ("bar", []); TermExp ("baz", [])])
             );
-            "nonsense_words :- foo; bar; baz.", (
-                Clause (
-                    TermExp ("nonsense_words", []),
-                    DisjunctionExp (
-                        DisjunctionExp (
-                            TermExp ("foo", []),
-                            TermExp ("bar", [])
-                        ),
-                        TermExp ("baz", [])
-                    )
-                )
-            );
-            "nonsense_words :- foo, bar; baz.", (
-                Clause (
-                    TermExp ("nonsense_words", []),
-                    DisjunctionExp (
-                        ConjunctionExp (
-                            TermExp ("foo", []),
-                            TermExp ("bar", [])
-                        ),
-                        TermExp ("baz", [])
-                    )
-                )
-            );
-            "nonsense_words :- foo; bar, baz.", (
-                Clause (
-                    TermExp ("nonsense_words", []),
-                    ConjunctionExp (
-                        DisjunctionExp (
-                            TermExp ("foo", []),
-                            TermExp ("bar", [])
-                        ),
-                        TermExp ("baz", [])
-                    )
-                )
-            );
+           
 
             (* Queries *)
             "?- cat(tom).", (
-                Query (TermExp ("cat", [TermExp ("tom", [])]))
+                Query ([TermExp ("cat", [TermExp ("tom", [])])])
             );
             "?- cat(X).", (
-                Query (TermExp ("cat", [VarExp "X"]))
+                Query ([TermExp ("cat", [VarExp "X"])])
             );
             "?- sibling(sally, erica).", (
-                Query (TermExp ("sibling", [TermExp ("sally", []); TermExp ("erica", [])]))
+                Query ([TermExp ("sibling", [TermExp ("sally", []); TermExp ("erica", [])])])
             );
             "?- sibling(sally, erica), sibling(john, joe).", (
-                Query (
-                    ConjunctionExp (
-                        TermExp ("sibling", [TermExp ("sally", []); TermExp ("erica", [])]),
-                        TermExp ("sibling", [TermExp ("john",  []); TermExp ("joe",   [])])
-                    )
-                )
-            );
-            "?- sibling(sally, erica); sibling(john, joe).", (
-                Query (
-                    DisjunctionExp (
-                        TermExp ("sibling", [TermExp ("sally", []); TermExp ("erica", [])]),
-                        TermExp ("sibling", [TermExp ("john",  []); TermExp ("joe",   [])])
-                    )
-                )
-            );
+                Query ([TermExp ("sibling", [TermExp ("sally", []); TermExp ("erica", [])]); TermExp ("sibling", [TermExp ("john", []); TermExp ("joe", [])])])
 
+            );
+           
             (* Combinations *)
             "cat(tom). animal(X) :- cat(X). ?- animal(X).", (
-                Clause (TermExp ("cat", [TermExp ("tom", [])]), ConstExp (BoolConst true))
+                Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)])
+
             );
         ]
     )
@@ -204,19 +114,16 @@ let parser_failure_test_suite =
             "cat 9";
             "cat,";
             "cat:-";
-            "cat;";
             "cat((";
             "cat(X.";
             "cat(, X).";
             "(cat).";
             "cat, dog.";
-            "cat; dog.";
             "coord(X, Y, Z)";
             "coord(X, Y, Z.";
             "coord X, Y, Z).";
             "coord X, Y, Z.";
             "coord(X Y Z).";
-            "coord(X; Y; Z).";
             "coord(X, Y, Z, ).";
             "coord(, X, Y, Z).";
             "VAR().";
@@ -227,7 +134,6 @@ let parser_failure_test_suite =
             "cat(X) :-.";
             "cat() :- cat() cat().";
             "parent_child(Z, X), parent_child(Z, Y) :- sibling(X, Y).";
-            "parent_child(Z, X); parent_child(Z, Y) :- sibling(X, Y).";
 
             (* Queries *)
             "?-";
@@ -235,6 +141,5 @@ let parser_failure_test_suite =
             "cat(tom) ?-";
             "cat(tom) ?- mouse(jerry).";
             "cat(tom), dog(spike) ?- mouse(jerry).";
-            "cat(tom); dog(spike) ?- mouse(jerry).";
         ]
     )


### PR DESCRIPTION
This makes a fundamental change to our ast. Now, a Clause has a head and a body where the body is a list of exps. The list represents a conjunction between all the exps in the list. Similarly a Query is a list of exps where the lsit represents a conjunction between all the exps in the list. This is to simplify the evaluation. Disjunction has been removed. I didn't modify any of the test files.