### PR TITLE
Get rid of BoolConst

### DIFF
--- a/docs/implementation.rst
+++ b/docs/implementation.rst
@@ -77,7 +77,7 @@ and is represented as an abstract syntax tree in a way that reflects this:
    Clause (
        TermExp ("cat", [TermExp ("tom", [])]),
        [
-           ConstExp (BoolConst true)
+           TermExp ("true", [])
        ]
    )
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -3,7 +3,6 @@ type const =
     | IntConst of int        (* integers *)
     | FloatConst of float    (* floats   *)
     | StringConst of string  (* strings  *)
-    | BoolConst of bool      (* booleans *)
 
 (* Expressions *)
 type exp =

--- a/src/common.ml
+++ b/src/common.ml
@@ -37,7 +37,6 @@ let string_of_const c =
     | IntConst    i -> "IntConst "      ^ string_of_int i
     | FloatConst  f -> "FloatConst "    ^ string_of_float f
     | StringConst s -> "StringConst \"" ^ String.escaped s ^ "\""
-    | BoolConst   b -> "BoolConst "     ^ string_of_bool b
 
 let rec string_of_exp e =
     match e with
@@ -52,7 +51,7 @@ let rec string_of_exp e =
 
 let string_of_exp_list g =
     "[" ^ (String.concat "; " (List.map string_of_exp g)) ^ "]"
-                      
+
 let string_of_dec d =
     match d with
     | Clause (e1, g) -> "Clause (" ^
@@ -86,7 +85,6 @@ let readable_string_of_const c =
     | IntConst i -> string_of_int i
     | FloatConst f -> string_of_float f
     | StringConst s -> "\"" ^ String.escaped s ^ "\""
-    | BoolConst b -> string_of_bool b
 
 (* Convert exp to a readable string *)
 let rec readable_string_of_exp e =

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -241,7 +241,7 @@ let rec eval_query (q, db, env) =
                                 match b with
                                 (* if the rule proved the subgoal (ie. rule was a
                                    fact) then recurse on remaining subgoals *)
-                                | ((ConstExp (BoolConst true)) :: ys) ->
+                                | ((TermExp ("true", _)) :: ys) ->
                                     ((eval_query (
                                         sub_lift_goals s gl,
                                         db,

--- a/src/evaluator.ml
+++ b/src/evaluator.ml
@@ -247,12 +247,6 @@ let rec eval_query (q, db, env) =
                                         db,
                                         env2
                                      )) @ r)
-                                | ((TermExp ("true", _)) :: ys) ->
-                                    ((eval_query (
-                                        sub_lift_goals s gl,
-                                        db,
-                                        env2
-                                     )) @ r)
                                 (* if rule wasn't a fact then we have more
                                    subgoals from the body of the rule 
                                    to prove *)

--- a/src/main.ml
+++ b/src/main.ml
@@ -49,4 +49,4 @@ let _ =
             );
         
     )
-    in (loop [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])])
+    in (loop [])

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -9,7 +9,7 @@
     let fact_sugar p =
         Clause (
             p,
-            [ConstExp (BoolConst true)]
+            [TermExp ("true", [])]
         )
 
     (* An atom can be regarded as a compound term with arity zero *)
@@ -54,7 +54,7 @@
 /* Types */
 %type <Ast.dec> clause
 %type <Ast.exp> predicate term structure
-%type <Ast.exp list> term_list predicate_list 
+%type <Ast.exp list> term_list predicate_list
 %type <Ast.const> constant
 
 %%

--- a/tests/common_test.ml
+++ b/tests/common_test.ml
@@ -43,8 +43,6 @@ let common_test_suite =
             string_of_const (IntConst (-3)),    "IntConst -3";
             string_of_const (FloatConst 27.3),  "FloatConst 27.3";
             string_of_const (StringConst "\n"), "StringConst \"\\n\"";
-            string_of_const (BoolConst true),   "BoolConst true";
-            string_of_const (BoolConst false),  "BoolConst false";
 
             (* Expressions *)
             string_of_exp (VarExp "X"),             "VarExp \"X\"";
@@ -55,24 +53,24 @@ let common_test_suite =
             string_of_exp_list (
                 [VarExp "X"; ConstExp (IntConst 10); TermExp ("blah", [VarExp "Y"; ConstExp (StringConst "hi"); TermExp ("end", [])])]
             ), "[VarExp \"X\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"Y\"; ConstExp (StringConst \"hi\"); TermExp (\"end\", [])])]";
-            
-            
+
+
             (* Declarations *)
             string_of_dec (
-                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
-            ), "Clause (TermExp (\"cat\", []), [ConstExp (BoolConst true)])";
+                Clause (TermExp ("cat", []), [TermExp ("true", [])])
+            ), "Clause (TermExp (\"cat\", []), [TermExp (\"true\", []])";
             string_of_dec (
                 Query ([TermExp ("cat", [TermExp ("tom", [])])])
             ), "Query ([TermExp (\"cat\", [TermExp (\"tom\", [])])])";
 
             (* Database *)
             string_of_db [
-                Clause (TermExp ("foo", []), [ConstExp (BoolConst true)]);
+                Clause (TermExp ("foo", []), [TermExp ("true", [])]);
                 Query ([TermExp ("bar", [])])
-            ], "[Clause (TermExp (\"foo\", []), [ConstExp (BoolConst true)]); Query ([TermExp (\"bar\", [])])]";
+            ], "[Clause (TermExp (\"foo\", []), [TermExp (\"true\", []]); Query ([TermExp (\"bar\", [])])]";
 
             (print_db [
-                Clause (TermExp ("foo", []), [ConstExp (BoolConst true)]);
+                Clause (TermExp ("foo", []), [TermExp ("true", [])]);
                 Query ([TermExp ("bar", [])])
                ]; "print_db"), "print_db";
 
@@ -80,8 +78,6 @@ let common_test_suite =
             readable_string_of_const (IntConst (-3)),    "-3";
             readable_string_of_const (FloatConst 27.3),  "27.3";
             readable_string_of_const (StringConst "\n"), "\"\\n\"";
-            readable_string_of_const (BoolConst true),   "true";
-            readable_string_of_const (BoolConst false),  "false";
 
             (* Readable Expression Strings *)
             readable_string_of_exp (VarExp "X"),             "X";
@@ -97,7 +93,7 @@ let common_test_suite =
             string_of_subs (
                 []
             ), "[]";
-            
+
             string_of_subs (
                 [(VarExp "X", TermExp ("hah", []))]
             ), "[(VarExp \"X\", TermExp (\"hah\", []))]";

--- a/tests/common_test.ml
+++ b/tests/common_test.ml
@@ -58,7 +58,7 @@ let common_test_suite =
             (* Declarations *)
             string_of_dec (
                 Clause (TermExp ("cat", []), [TermExp ("true", [])])
-            ), "Clause (TermExp (\"cat\", []), [TermExp (\"true\", []])";
+            ), "Clause (TermExp (\"cat\", []), [TermExp (\"true\", [])])";
             string_of_dec (
                 Query ([TermExp ("cat", [TermExp ("tom", [])])])
             ), "Query ([TermExp (\"cat\", [TermExp (\"tom\", [])])])";
@@ -67,7 +67,7 @@ let common_test_suite =
             string_of_db [
                 Clause (TermExp ("foo", []), [TermExp ("true", [])]);
                 Query ([TermExp ("bar", [])])
-            ], "[Clause (TermExp (\"foo\", []), [TermExp (\"true\", []]); Query ([TermExp (\"bar\", [])])]";
+            ], "[Clause (TermExp (\"foo\", []), [TermExp (\"true\", [])]); Query ([TermExp (\"bar\", [])])]";
 
             (print_db [
                 Clause (TermExp ("foo", []), [TermExp ("true", [])]);

--- a/tests/evaluator_test.ml
+++ b/tests/evaluator_test.ml
@@ -79,30 +79,30 @@ let evaluator_test_suite =
           (string_of_exp_list
              (sub_lift_goals
                 ([(VarExp "X", VarExp "1")])
-                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp(BoolConst true)])])
+                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp (IntConst 1)])])
              )
-          ), "[VarExp \"1\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"1\"; VarExp \"Y\"; ConstExp (BoolConst true)])]";
+          ), "[VarExp \"1\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"1\"; VarExp \"Y\"; ConstExp (IntConst 1)])]";
 
           (string_of_exp_list
              (sub_lift_goals
                 ([])
-                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp(BoolConst true)])])
+                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp (IntConst 1)])])
              )
-          ), "[VarExp \"X\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"X\"; VarExp \"Y\"; ConstExp (BoolConst true)])]";
+          ), "[VarExp \"X\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"X\"; VarExp \"Y\"; ConstExp (IntConst 1)])]";
 
           (string_of_exp_list
              (sub_lift_goals
                 ([(VarExp "X", VarExp "1"); (VarExp "Z", VarExp "blu")])
-                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp(BoolConst true)])])
+                ([VarExp("X"); ConstExp(IntConst 10); TermExp("blah", [VarExp "X"; VarExp "Y"; ConstExp (IntConst 1)])])
              )
-          ), "[VarExp \"1\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"1\"; VarExp \"Y\"; ConstExp (BoolConst true)])]";
+          ), "[VarExp \"1\"; ConstExp (IntConst 10); TermExp (\"blah\", [VarExp \"1\"; VarExp \"Y\"; ConstExp (IntConst 1)])]";
 
           (* Renaming variables in a declaration*)
           (string_of_dec
              (rename_vars_in_dec
-                (Clause(TermExp("age",[TermExp("zaid",[]);ConstExp(IntConst 10) ]), [(ConstExp (BoolConst true))]))
+                (Clause(TermExp("age",[TermExp("zaid",[]);ConstExp(IntConst 10) ]), [(ConstExp (IntConst 1))]))
              )
-          ), "Clause (TermExp (\"age\", [TermExp (\"zaid\", []); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)])";
+          ), "Clause (TermExp (\"age\", [TermExp (\"zaid\", []); ConstExp (IntConst 10)]), [ConstExp (IntConst 1)])";
 
           (turn_to_unit (reset());
            string_of_dec
@@ -406,7 +406,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp ("male", [TermExp ("elizabeth", [])])],
-                   [Clause (TermExp("female", [TermExp("elizabeth", [ConstExp (BoolConst true)])]), [])],
+                   [Clause (TermExp("female", [TermExp("elizabeth", [TermExp ("true", [])])]), [])],
                    []
                  )
               )
@@ -418,7 +418,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp ("male", [TermExp ("elizabeth", [])])],
-                   [Clause (TermExp("elizabeth", [TermExp("male", [])]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp("elizabeth", [TermExp("male", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -430,7 +430,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp ("female", [TermExp ("elizabeth", [])])],
-                   [Clause (TermExp("female", [TermExp("elizabeth", [])]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp("female", [TermExp("elizabeth", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -448,13 +448,13 @@ let evaluator_test_suite =
               )
               ([])
               (0)
-           ), "false\n";
+           ), "true\n";
 
            (string_of_res
               (eval_query
                  (
                    [TermExp ("female", [TermExp ("elizabeth", [])])],
-                   [Clause (TermExp("female", [TermExp("elizabeth", [])]), [TermExp("true", [])]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp("female", [TermExp("elizabeth", [])]), [TermExp("true", [])])],
                    []
                  )
               )
@@ -466,7 +466,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp ("male", [TermExp ("elizabeth", [])])],
-                   [Query([TermExp ("male", [TermExp ("elizabeth", [])])]); Clause (TermExp("female", [TermExp("elizabeth", [])]), [TermExp("true", [])]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Query([TermExp ("male", [TermExp ("elizabeth", [])])]); Clause (TermExp("female", [TermExp("elizabeth", [])]), [TermExp("true", [])])],
                    []
                  )
               )
@@ -490,7 +490,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("age", [TermExp("zaid",[]); VarExp "Y"])],
-                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -502,7 +502,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("age", [TermExp("zaid",[]); VarExp "Y"])],
-                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [TermExp ("true", [])]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -514,7 +514,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("age", [VarExp "E"; VarExp "Z"])],
-                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [TermExp ("true", [])]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -526,7 +526,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("age", [VarExp "X"; ConstExp (IntConst 5)])],
-                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [TermExp ("true", [])]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -538,7 +538,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp ("a", [])],
-                   [Clause (TermExp ("a", []), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("a", []), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -550,7 +550,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("age", [VarExp "X"; VarExp "Y"]); TermExp("female", [VarExp "X"])],
-                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [ConstExp (BoolConst true)]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [ConstExp (BoolConst true)]); Clause (TermExp ("age", [TermExp ("ann", []); ConstExp (IntConst 12)]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("zaid", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [ConstExp (StringConst "adam")]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("ann", [])]), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("age", [ConstExp (StringConst "adam"); ConstExp (IntConst 10)]), [TermExp ("true", [])]);Clause (TermExp ("age", [TermExp ("zaid", []); ConstExp (IntConst 5)]), [TermExp ("true", [])]); Clause (TermExp ("age", [TermExp ("ann", []); ConstExp (IntConst 12)]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("zaid", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [ConstExp (StringConst "adam")]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("ann",[])]),[TermExp ("true", [])])],
                    []
                  )
               )
@@ -562,7 +562,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("sibling", [TermExp("sally",[]); TermExp("erica",[])])],
-                   [Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("mother_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("father_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("sibling", [VarExp "X"; VarExp "Y"]), [TermExp ("parent_child", [VarExp "Z"; VarExp "X"]); TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])]); Clause (TermExp ("father_child", [TermExp ("mike", []); TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("erica", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("sally", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("mother_child", [TermExp ("trude", []); TermExp ("sally", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("mother_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("father_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("sibling", [VarExp "X"; VarExp "Y"]), [TermExp ("parent_child", [VarExp "Z"; VarExp "X"]); TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])]); Clause (TermExp ("father_child", [TermExp ("mike", []); TermExp ("tom", [])]), [TermExp ("true", [])]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("erica", [])]), [TermExp ("true", [])]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("sally", [])]), [TermExp ("true", [])]); Clause (TermExp ("mother_child", [TermExp ("trude", []); TermExp ("sally", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -574,7 +574,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("sibling", [VarExp "Z"; VarExp "E"])],
-                   [Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("mother_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("father_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("sibling", [VarExp "X"; VarExp "Y"]), [TermExp ("parent_child", [VarExp "Z"; VarExp "X"]); TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])]); Clause (TermExp ("father_child", [TermExp ("mike", []); TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("erica", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("sally", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("mother_child", [TermExp ("trude", []); TermExp ("sally", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("mother_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("parent_child", [VarExp "X"; VarExp "Y"]), [TermExp ("father_child", [VarExp "X"; VarExp "Y"])]); Clause (TermExp ("sibling", [VarExp "X"; VarExp "Y"]), [TermExp ("parent_child", [VarExp "Z"; VarExp "X"]); TermExp ("parent_child", [VarExp "Z"; VarExp "Y"])]); Clause (TermExp ("father_child", [TermExp ("mike", []); TermExp ("tom", [])]), [TermExp ("true", [])]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("erica", [])]), [TermExp ("true", [])]); Clause (TermExp ("father_child", [TermExp ("tom", []); TermExp ("sally", [])]), [TermExp ("true", [])]); Clause (TermExp ("mother_child", [TermExp ("trude", []); TermExp ("sally", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -586,7 +586,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("animal", [VarExp "X"; VarExp "Y"])],
-                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -598,7 +598,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("animal", [VarExp "X"; VarExp "Y"]); VarExp "Z"],
-                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -610,7 +610,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [VarExp "X"],
-                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -622,7 +622,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("animal", [VarExp "X"; VarExp "Y"]); VarExp "Z"],
-                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])])],
                    []
                  )
               )
@@ -634,7 +634,7 @@ let evaluator_test_suite =
               (eval_query
                  (
                    [TermExp("animal", [VarExp "X"; VarExp "Y"]); VarExp "Z"],
-                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])],
+                   [Clause (TermExp ("animal", [VarExp "X"; VarExp "Y"]), [TermExp ("cat", [VarExp "X"])]); Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])])],
                    [(VarExp "X", TermExp("eh",[VarExp "X"]))]
                  )
               )
@@ -642,97 +642,111 @@ let evaluator_test_suite =
               (3)
            ), "false\n";
 
+
+
+            (string_of_res
+              (eval_query
+                 (
+                   [TermExp("b", [TermExp("a", [TermExp("true",[])])])],
+                   [Clause (TermExp("b",[VarExp "X"]), [TermExp("a", [VarExp "X"])]); Clause (TermExp("a",[TermExp("true",[])]), [TermExp ("true", [])])],
+                   []
+                 )
+              )
+              ([])
+              (0)
+            ), "false\n";
+
            (* Adding declarations to db *)
            (string_of_db
               (add_dec_to_db
                  (
-                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]),
+                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])]),
                    []
                  )
               )
-           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (add_dec_to_db
                  (
-                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]),
-                   [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])]),
+                   []
                  )
               )
-           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (add_dec_to_db
                  (
-                   Clause (TermExp ("true", []), [ConstExp (BoolConst true)]),
-                   [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   Clause (TermExp ("true", []), [TermExp ("true", [])]),
+                   []
                  )
               )
-           ), "[Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[]";
 
            (string_of_db
               (add_dec_to_db
                  (
-                   Clause (TermExp ("true", [TermExp ("blah",[])]), [ConstExp (BoolConst true)]),
-                   [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   Clause (TermExp ("true", [TermExp ("blah",[])]), [TermExp ("true", [])]),
+                   []
                  )
               )
-           ), "[Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[]";
 
            (string_of_db
               (add_dec_to_db
                  (
                    Query ([TermExp ("parent", [VarExp "X"; TermExp ("charles1", [])]); TermExp ("male", [VarExp "X"])]),
-                   [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   []
                  )
               )
-           ), "[Query ([TermExp (\"parent\", [VarExp \"X\"; TermExp (\"charles1\", [])]); TermExp (\"male\", [VarExp \"X\"])]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Query ([TermExp (\"parent\", [VarExp \"X\"; TermExp (\"charles1\", [])]); TermExp (\"male\", [VarExp \"X\"])])]";
 
            (* Evaluating a declaration *)
            (string_of_db
               (eval_dec
                  (
-                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [ConstExp (BoolConst true)]),
-                   [Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   Clause (TermExp ("cat", [TermExp ("tom", [])]), [TermExp ("true", [])]),
+                   []
                  )
               )
-           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"cat\", [TermExp (\"tom\", [])]), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (eval_dec
                  (
                    Query ([TermExp ("male", [TermExp ("charles1", [])])]),
-                   [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("george1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("george1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james1", [])]), [TermExp ("true", [])])]
                  )
               )
-           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (eval_dec
                  (
                    Query ([TermExp ("male", [TermExp ("charles1", [])]);TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1",[] )])]),
-                   [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("george1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                   [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("george1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james1", [])]), [TermExp ("true", [])])]
                  )
               )
-           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (eval_dec
                  (
                   Query ([TermExp ("parent", [VarExp "X"; TermExp ("charles1", [])]); TermExp ("male", [VarExp "X"])]),
-                  [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("george1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                  [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("george1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("true", []), [TermExp ("true", [])])]
                  )
               )
-           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"true\", []), [TermExp (\"true\", [])])]";
 
            (string_of_db
               (eval_dec
                  (
                   Query ([TermExp ("parent", [VarExp "X"; TermExp ("charles1", [])]); TermExp ("female", [VarExp "X"])]),
-                  [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("george1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("male", [TermExp ("james1", [])]), [ConstExp (BoolConst true)]); Clause (TermExp ("true", []), [ConstExp (BoolConst true)])]
+                  [Clause (TermExp ("parent", [TermExp ("george1", []); TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("sophia", []); TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("james2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("catherine", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles2", []); TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("elizabeth", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("parent", [TermExp ("charles1", []); TermExp ("james1", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("sophia", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("elizabeth", [])]), [TermExp ("true", [])]); Clause (TermExp ("female", [TermExp ("catherine", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("george1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles2", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("charles1", [])]), [TermExp ("true", [])]); Clause (TermExp ("male", [TermExp ("james1", [])]), [TermExp ("true", [])])]
                  )
               )
-           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [ConstExp (BoolConst true)]); Clause (TermExp (\"true\", []), [ConstExp (BoolConst true)])]";
+           ), "[Clause (TermExp (\"parent\", [TermExp (\"george1\", []); TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"sophia\", []); TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"james2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"catherine\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles2\", []); TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"elizabeth\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"parent\", [TermExp (\"charles1\", []); TermExp (\"james1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"sophia\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"elizabeth\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"female\", [TermExp (\"catherine\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"george1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles2\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"charles1\", [])]), [TermExp (\"true\", [])]); Clause (TermExp (\"male\", [TermExp (\"james1\", [])]), [TermExp (\"true\", [])])]";
            
            
         ]

--- a/tests/parser_test.ml
+++ b/tests/parser_test.ml
@@ -20,17 +20,17 @@ let parser_test_suite =
         [
             (* Facts *)
             "cat.", (
-                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
+                Clause (TermExp ("cat", []), [TermExp ("true", [])])
             );
             "cat().", (
-                Clause (TermExp ("cat", []), [ConstExp (BoolConst true)])
+                Clause (TermExp ("cat", []), [TermExp ("true", [])])
             );
             "cat(tom).", (
                 Clause (
                     TermExp (
                         "cat", [TermExp ("tom", [])]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -39,7 +39,7 @@ let parser_test_suite =
                     TermExp (
                         "cat", [TermExp ("tom", [])]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -48,7 +48,7 @@ let parser_test_suite =
                     TermExp (
                         "cat", [VarExp "X"]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -61,7 +61,7 @@ let parser_test_suite =
                             VarExp "Z"
                         ]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -74,7 +74,7 @@ let parser_test_suite =
                             ConstExp (IntConst 3)
                         ]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -87,7 +87,7 @@ let parser_test_suite =
                             ConstExp (FloatConst 3.)
                         ]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
@@ -99,12 +99,15 @@ let parser_test_suite =
                             ConstExp (StringConst "jill")
                         ]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );
 
             (* Rules *)
+            "cat :- true.", (
+                Clause (TermExp ("cat", []), [TermExp ("true", [])])
+            );
             "animal(X) :- cat(X).", (
                 Clause (
                     TermExp (
@@ -188,7 +191,7 @@ let parser_test_suite =
                             TermExp ("tom", [])
                         ]
                     ), [
-                        ConstExp (BoolConst true)
+                        TermExp ("true", [])
                     ]
                 )
             );


### PR DESCRIPTION
The purpose of this PR is to remove `BoolConst` from the AST. This allows for a uniform treatment of "true" and "false" in parsing and evaluating. The following expressions:
```prolog
cat.
cat :- true.
```
should have the same representation in the AST now.